### PR TITLE
Allow installing plugin when cordova-plugin-device 3.0.0 is installed 

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
         <clobbers target="LaunchReview"/>
     </js-module>
 
-    <dependency id="cordova-plugin-device" version="^2.0.3" />
+    <dependency id="cordova-plugin-device" version=">=2.0.3 <4.0.0" />
 
     <!-- ios -->
     <platform name="ios">


### PR DESCRIPTION
Fixes #38

Just a minor change to plugin.xml to allow installing the plugin if cordova-plugin-device 3.0.0 is installed 